### PR TITLE
Handle missing TLE data before orbit propagation

### DIFF
--- a/src/components/Scene/OrbitCanvas.tsx
+++ b/src/components/Scene/OrbitCanvas.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from "react";
+
+interface TLE {
+  line1?: string;
+  line2?: string;
+}
+
+interface OrbitCanvasProps {
+  tle?: TLE;
+}
+
+function propagateOrbit(line1: string, line2: string) {
+  // Placeholder for orbit propagation logic
+  console.log("Propagating orbit with", line1, line2);
+}
+
+function fallbackTrajectory() {
+  // Placeholder for fallback trajectory logic
+  console.log("Using fallback trajectory");
+}
+
+const OrbitCanvas: React.FC<OrbitCanvasProps> = ({ tle }) => {
+  useEffect(() => {
+    if (tle?.line1 && tle?.line2) {
+      propagateOrbit(tle.line1, tle.line2);
+    } else {
+      // Skip propagation or provide fallback trajectory
+      console.warn("TLE is missing line1 or line2; skipping propagation.");
+      fallbackTrajectory();
+    }
+  }, [tle]);
+
+  return <div id="orbit-canvas" />;
+};
+
+export default OrbitCanvas;


### PR DESCRIPTION
## Summary
- add OrbitCanvas component with TLE availability checks before propagation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fmsim')*

------
https://chatgpt.com/codex/tasks/task_e_68a71a67d370832cab36eba38203009b